### PR TITLE
OPENDJ-2220 Handle backports in known issues lists

### DIFF
--- a/src/main/python/queries.cfg
+++ b/src/main/python/queries.cfg
@@ -11,13 +11,27 @@
 #OpenAM Java EE Agents 3.3.0 Fixed Bugs : project = OpenAM AND component = "j2ee agents" AND fixVersion in ("Agents-3.1.0-Xpress", "Agents-3.2.0", "Agents-3.3.0") AND resolution = Fixed AND labels = release-notes
 #OpenAM Java EE Agents 3.3.0 Open Issues : project = OpenAM AND component = "j2ee agents" AND resolution = Unresolved AND labels = release-notes
 
+#
+# IMPORTANT NOTE - DO NOT DELETE
+#
+# OpenDJ has backport issues that should not show up in the "Open Issues" lists.
+# See https://bugster.forgerock.org/jira/browse/OPENDJ-2220 for details.
+#
+# The backport issues can be excluded with the following query fragment:
+# NOT (issueFunction in linkedIssuesOf("project = OPENDJ", "is backported by"))
+#
+# Issues for which there is a backport fixed in the current version
+# can be excluded with a fragment similar to the following (for OpenDJ 2.6.3):
+# NOT (issueFunction in linkedIssuesOf("project = OPENDJ AND fixVersion = '2.6.3' AND resolution = Fixed", "is a backport of"))
+#
+
 OpenDJ 2.8.0 New : project = OpenDJ AND type in (Improvement, "New Feature", Story) AND resolution = Fixed AND fixVersion = 2.8.0 AND component not in (Documentation, QA, "opendj sdk")
 OpenDJ 2.8.0 Fixed Bugs : project = OpenDJ AND type = Bug AND resolution = Fixed AND fixVersion = 2.8.0 AND component not in (Documentation, QA, "opendj sdk") AND labels = release-notes
-OpenDJ 2.8.0 Open Issues : project = OpenDJ AND type = Bug AND (resolution = unresolved OR (resolution = Fixed AND fixVersion != 2.8.0 AND fixVersion in (3.0.0, 2.6.3))) AND component not in (Documentation, QA, "opendj sdk", "JE backend") AND labels = release-notes AND labels != backport
+OpenDJ 2.8.0 Open Issues : project = OpenDJ AND type = Bug AND (resolution = unresolved OR (resolution = Fixed AND fixVersion != 2.8.0 AND fixVersion in (3.0.0, 2.6.3))) AND component not in (Documentation, QA, "opendj sdk", "JE backend") AND labels = release-notes AND NOT (issueFunction in linkedIssuesOf("project = OPENDJ", "is backported by")) AND NOT (issueFunction in linkedIssuesOf("project = OPENDJ AND fixVersion = '2.8.0' AND resolution = fixed", "is a backport of"))
 
 OpenDJ 2.6.3 New : project = OpenDJ AND type in (Improvement, "New Feature", Story) AND resolution = Fixed AND fixVersion = "2.6.3" AND component not in (Documentation, QA)
 OpenDJ 2.6.3 Fixed Bugs : project = OpenDJ AND type = Bug AND resolution = Fixed AND fixVersion = "2.6.3" AND component not in (Documentation, QA) AND labels = release-notes
-OpenDJ 2.6.3 Open Issues : project = OpenDJ AND type = Bug AND (resolution = unresolved or (fixVersion not in ("2.6.0", "2.6.1", "2.6.2", "2.6.3") AND fixVersion in ("2.8.0", "3.0.0"))) AND component not in (Documentation, QA, "opendj sdk", "next gen backend") AND labels = release-notes
+OpenDJ 2.6.3 Open Issues : project = OpenDJ AND type = Bug AND (resolution = unresolved or (fixVersion not in ("2.6.0", "2.6.1", "2.6.2", "2.6.3") AND fixVersion in ("2.8.0", "3.0.0"))) AND component not in (Documentation, QA, "opendj sdk", "next gen backend") AND labels = release-notes AND NOT (issueFunction in linkedIssuesOf("project = OPENDJ", "is backported by")) AND NOT (issueFunction in linkedIssuesOf("project = OPENDJ AND fixVersion = '2.6.3' AND resolution = fixed", "is a backport of"))
 
 #OpenDJ 2.6.2 + 2.6.9 SDK New : project = OpenDJ AND type in (Improvement, "New Feature", Story) AND resolution = Fixed AND (fixVersion = "2.6.2" OR fixVersion in ("2.6.8-sdk", "2.6.9-sdk")) AND component not in (Documentation, QA)
 #OpenDJ 2.6.2 + 2.6.9 SDK Fixed Bugs : project = OpenDJ AND type = Bug AND resolution = Fixed AND (fixVersion = "2.6.2" OR fixVersion in ("2.6.8-sdk", "2.6.9-sdk")) AND component not in (Documentation, QA) AND labels = release-notes


### PR DESCRIPTION
This patch adds a note and examples for excluding backports
and issues with fixed backports in the current release
from a generated list of OpenDJ Known Issues.