### PR TITLE
OPENAM-8598 Update queries.cfg for Web Policy Agents 4.0.1

### DIFF
--- a/src/main/python/queries.cfg
+++ b/src/main/python/queries.cfg
@@ -3,9 +3,9 @@
 #OpenAM 11.0.2 Fixed Bugs : project = OpenAM AND fixVersion = "11.0.2" AND resolution = Fixed AND labels = release-notes
 #OpenAM 11.0.2 Open Issues : labels = release-notes AND project = OpenAM AND (resolution = unresolved OR (fixVersion not in ("10.0.0", "10.1.0-Xpress", "11.0.0","11.0.1","11.0.2") AND fixVersion in ("11.0.3", "12.0.0"))) AND type = bug AND (component is EMPTY OR component not in (QA, Documentation, "web agents", "j2ee agents"))
 
-#OpenAM Web Agents 3.3.3 New : project = OPENAM AND resolution = fixed AND fixVersion in ("Agents-3.3.2", "Agents-3.3.3") AND component = "web agents" AND type in ("New Feature", Improvement)
-#OpenAM Web Agents 3.3.3 Fixed Bugs : project = OpenAM AND component = "web agents" AND fixVersion in ("Agents-3.3.2", "Agents-3.3.3") AND resolution = Fixed AND labels = release-notes
-#OpenAM Web Agents 3.3.3 Open Issues : project = OpenAM AND component = "web agents" AND resolution = Unresolved AND labels = release-notes
+# OpenAM Web Agents 4.0.1 Improvements : project = OpenAM AND component = "web agents" AND fixVersion IN (Agents-4.0.1) AND resolution = Fixed AND type IN ("New Feature", Improvement) AND Cases IS NOT EMPTY ORDER BY id
+OpenAM Web Agents 4.0.1 Key Fixes :    project = OpenAM AND component = "web agents" AND fixVersion IN (Agents-4.0.1) AND resolution = Fixed AND type NOT IN ("New Feature", Improvement) AND Cases IS NOT EMPTY ORDER BY id
+OpenAM Web Agents 4.0.1 Known Issues : project = OpenAM AND component = "web agents" AND resolution = Unresolved AND labels = release-notes
 
 #OpenAM Java EE Agents 3.3.0 New : project = OPENAM AND resolution = fixed AND fixVersion in ("Agents-3.1.0-Xpress", "Agents-3.2.0", "Agents-3.3.0") and component = "j2ee agents" and type in ("New Feature", Improvement)
 #OpenAM Java EE Agents 3.3.0 Fixed Bugs : project = OpenAM AND component = "j2ee agents" AND fixVersion in ("Agents-3.1.0-Xpress", "Agents-3.2.0", "Agents-3.3.0") AND resolution = Fixed AND labels = release-notes


### PR DESCRIPTION
Jiras not marked with `release-notes` label, so instead capturing entries that have at least one associated Case ID.